### PR TITLE
fix issue #1: handle the case of special characters in the key

### DIFF
--- a/buffoon.cc
+++ b/buffoon.cc
@@ -4,7 +4,8 @@
 namespace Buffoon {
 
     std::string Buffoon::findValueByKey(const std::string &json_like_string, const std::string &key) {
-      std::regex key_value_pattern("\"" + key + R"("\s*:\s*("[^"]*"|\d+|\-?\d+\.\d+|true|false|null))");
+      std::string escapedKey = escapeSpecialChars(key);
+      std::regex key_value_pattern("\"" + escapedKey + R"("\s*:\s*("[^"]*"|\d+|\-?\d+\.\d+|true|false|null))");
       std::smatch match;
 
       if (std::regex_search(json_like_string, match, key_value_pattern)) {

--- a/buffoon.h
+++ b/buffoon.h
@@ -5,6 +5,16 @@
 
 namespace Buffoon {
   class Buffoon {
+    static std::string escapeSpecialChars(const std::string& key) {
+        std::string escapedKey;
+        for (char c : key) {
+          if (c == '$' || c == '^' || c == '.' || c == '*' || c == '+' || c == '?' || c == '(' || c == ')' || c == '[' || c == ']' || c == '{' || c == '}' || c == '|') {
+            escapedKey += '\\';
+          }
+          escapedKey += c;
+        }
+        return escapedKey;
+    }
   public:
       /**
        * method to find the value keyed by "payload" from JSON-like string


### PR DESCRIPTION
Issue #1 was fixed in this PR.

Solution: we need to put an escape sign(**"\\"**) before every special characters if any in the key.