### PR TITLE
Doc support: add guideline on how this repo can be used as a git repo in a bazel project

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,4 +63,14 @@ So far, _Buffoon_ is a single header library with only a single implementation f
          ]
    )
    ```
+##### Us it by fetching as a remote git repository
+It is quite similar to the above discussed method except that you add it in your **WORKSPACE** file as a git repository:
+```
+git_repository(
+    name = "buffoon",
+    remote = "https://github.com/shiponcs/buffoon.git",
+    branch = "main",
+)
+```
+
 #### C. Using CMake


### PR DESCRIPTION
partially addresses #3 

complement to #4 #5 